### PR TITLE
Made the SDK bindgen process closer to the compilation done by MSFS

### DIFF
--- a/msfs/build.rs
+++ b/msfs/build.rs
@@ -1,29 +1,95 @@
+use std::path::{Path, PathBuf};
+
 fn main() {
-    let msfs_sdk = std::env::var("MSFS_SDK").unwrap_or_else(calculate_msfs_sdk_path);
-    println!("Found MSFS SDK: {:?}", msfs_sdk);
+    let msfs_sdk_path = msfs_sdk_path();
+    println!("Found MSFS SDK: {}", msfs_sdk_path);
 
     println!("cargo:rerun-if-changed=src/bindgen_support/wrapper.h");
     let bindings = bindgen::Builder::default()
-        .clang_arg(format!("-I{}", msfs_sdk))
-        .clang_arg(format!("-I{}", "src/bindgen_support"))
+        // On 2020-10-16, we observed what command line args were passed to clang by
+        // MSFS SDK (version 0.6.0.0) when building a WASM gauge from Visual Studio 2019 using the
+        // SDK's provided extension (the useless ones were thrown out).
+
+        // It's unlikely that these variables will significantly change over the course of
+        // MSFS SDK's lifecycle, but if they do -- the values can be recaptured by going to:
+        //   Tools -> Options -> Projects and Solutions -> Build and Run
+        // And setting:
+        //   MSBuild project build output verbosity = Diagnostic
+
+        // Then the command used to build the file will show up. (Search for "clang-cl.exe")
+        // A caveat is that the version of clang used by the MSFS SDK is a version with
+        // compatibility with MSVC's cl.exe, which means the flags will be non-standard.
+
+        // The cl.exe flags can be read about here, and it should be a straightforward decoding:
+        // https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options?view=vs-2019
+        .clang_arg(format!("-I{}/WASM/wasi-sysroot/include", &msfs_sdk_path))
+        .clang_arg(format!("-I{}/WASM/wasi-sysroot/include/c++/v1", &msfs_sdk_path))
+        .clang_arg(format!("-I{}/WASM/include", &msfs_sdk_path))
+        .clang_arg(format!("-I{}/SimConnect SDK/include", &msfs_sdk_path))
+        .clang_arg(format!("-D {}", get_debug_macro()))
+        .clang_arg("-D _MSFS_WASM")
+        .clang_arg("-D _STRING_H_CPLUSPLUS_98_CONFORMANCE_")
+        .clang_arg("-D _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_")
+        .clang_arg("-D _LIBCPP_NO_EXCEPTIONS")
+        .clang_arg("-D _LIBCPP_HAS_NO_THREADS")
+        .clang_arg("-D _MBCS")
         .clang_arg("-fms-extensions")
+        .clang_arg("-m32")
         .clang_arg("-xc++")
+        .clang_arg("--target=wasm32-unknown-wasi")
+        .clang_arg(format!("--sysroot={}/WASM/wasi-sysroot", &msfs_sdk_path))
         .header("src/bindgen_support/wrapper.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .impl_debug(true)
         .generate()
         .unwrap();
-    let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_path = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .unwrap();
 }
 
-fn calculate_msfs_sdk_path(_: std::env::VarError) -> String {
-    for p in ["/mnt/c/MSFS SDK", r"C:\MSFS SDK"].iter() {
-        if std::path::Path::new(p).exists() {
-            return p.to_string();
+/// This function returns the location of the MSFS SDK.
+///
+/// It will first try to use the MSFS_SDK environment variable, and then check in the default
+/// install directories.
+fn msfs_sdk_path() -> String {
+    if let Ok(path) = std::env::var("MSFS_SDK") {
+        println!("MSFS_SDK environment variable is set to: {}", path);
+        if Path::new(&path).exists() {
+            println!("MSFS_SDK environment variable points to a path that exists");
+            return path;
         }
+        println!("MSFS_SDK environment variable points to a path that is invalid or does not exist");
+    } else {
+        println!("MSFS_SDK environment variable is not set");
     }
-    panic!("Could not locate MSFS SDK. Make sure you have it installed or try setting the MSFS_SDK env var.");
+
+    let path;
+    let environment;
+    if cfg!(windows) {
+        path = r"C:\MSFS SDK";
+        environment = "Windows";
+    } else {
+        path = r"/mnt/c/MSFS SDK";
+        environment = "non-Windows";
+    }
+    println!("Detected {}: Using the MSFS SDK default path of {}", environment, path);
+
+    if Path::new(path).exists() {
+        println!("Default MSFS SDK path exists");
+        return path.to_owned();
+    }
+
+    panic!("Unable to find a valid path to the MSFS SDK. \
+           Check the preceding stdout messages, \
+           and potentially set the MSFS_SDK environment variable to the right path.");
+}
+
+fn get_debug_macro() -> &'static str {
+    return if cfg!(debug_assertions) {
+        "_DEBUG"
+    } else {
+        "NDEBUG"
+    }
 }

--- a/msfs/src/bindgen_support/bits/alltypes.h
+++ b/msfs/src/bindgen_support/bits/alltypes.h
@@ -1,6 +1,0 @@
-#ifndef MSFS_RS_ALLTYPES_H
-#define MSFS_RS_ALLTYPES_H
-
-#include <stdint.h>
-
-#endif //MSFS_RS_ALLTYPES_H

--- a/msfs/src/bindgen_support/stdio.h
+++ b/msfs/src/bindgen_support/stdio.h
@@ -1,4 +1,0 @@
-#ifndef MSFS_RS_STDIO_H
-#define MSFS_RS_STDIO_H
-
-#endif //MSFS_RS_STDIO_H

--- a/msfs/src/bindgen_support/wchar.h
+++ b/msfs/src/bindgen_support/wchar.h
@@ -1,4 +1,0 @@
-#ifndef MSFS_RS_WCHAR_H
-#define MSFS_RS_WCHAR_H
-
-#endif //MSFS_RS_WCHAR_H

--- a/msfs/src/bindgen_support/wrapper.h
+++ b/msfs/src/bindgen_support/wrapper.h
@@ -1,10 +1,19 @@
 // Compat defines
-#define _MSFS_WASM 1
 #define SIMCONNECTAPI __attribute__((visibility("default"))) extern "C" HRESULT
 #define FSAPI __attribute__((visibility("default")))
 
-// External API headers, assumes MSFS_SDK in include path
-#include <WASM/include/MSFS/Legacy/gauges.h>
-#include <WASM/include/MSFS/MSFS.h>
-#include <WASM/include/MSFS/MSFS_Render.h>
-#include <SimConnect SDK/include/SimConnect.h>
+#include <MSFS/MSFS.h>
+#include <MSFS/MSFS_Render.h>
+#include <MSFS/MSFS_WindowsTypes.h>
+#include <SimConnect.h>
+#include <MSFS/Legacy/gauges.h>
+
+// Exports using the FSAPI definition in MSFS/Legacy/gauges.h need to be explicitly exported due to the FSAPI macro
+// being redefined without visibility
+
+#define FSAPI __attribute__((visibility("default")))
+
+FLOAT64 FSAPI aircraft_varget(ENUM simvar, ENUM units, SINT32 index);
+BOOL FSAPI execute_calculator_code(PCSTRINGZ code, FLOAT64* fvalue, SINT32* ivalue, PCSTRINGZ* svalue);
+ENUM FSAPI get_aircraft_var_enum(PCSTRINGZ simvar);
+ENUM FSAPI get_units_enum(PCSTRINGZ unitname);


### PR DESCRIPTION
Makes some changes to bring the bindgen build closer to what MSFS does when building C++. This creates some headaches (as FSAPI visability is clobbered in gauges.h) but is healthier for type safety.

Additionally, minor changes was made to detecting the MSFS SDK path detection to make that process likely more robust.