### PR TITLE
chore: update rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver =  "3"
 members = [
   "msfs",
   "msfs_sdk",

--- a/msfs/Cargo.toml
+++ b/msfs/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "msfs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["snek"]
-edition = "2018"
+edition = "2024"
 description = "Rust bindings for the MSFS SDK"
 license = "MIT"
 
 [dependencies]
-msfs_derive = { path = "../msfs_derive", version = "0.2.0" }
+msfs_derive = { path = "../msfs_derive", version = "0.3.0" }
 futures = "0.3"
 libc = "0.2"
 
 [build-dependencies]
 bindgen = "0.72"
-msfs_sdk = { path = "../msfs_sdk", version = "0.1.0" }
+msfs_sdk = { path = "../msfs_sdk", version = "0.2.0" }
 cc = "1.0"

--- a/msfs/build.rs
+++ b/msfs/build.rs
@@ -5,7 +5,10 @@ fn main() {
 
     // build nanovg wrapper
     if wasm {
-        std::env::set_var("AR", "llvm-ar");
+        unsafe {
+            std::env::set_var("AR", "llvm-ar");
+        }
+
         cc::Build::new()
             .compiler("clang")
             .flag(format!("--sysroot={msfs_sdk}/WASM/wasi-sysroot"))
@@ -39,6 +42,7 @@ fn main() {
             .blocklist_function("nvgStrokePaint")
             .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
             .rustified_enum("SIMCONNECT_EXCEPTION")
+            .layout_tests(false)
             .impl_debug(false)
             // `opaque_type` added to avoid alignment errors. These alignment errors are caused
             // because virtual methods are not well supported in rust-bindgen.

--- a/msfs/src/commbus.rs
+++ b/msfs/src/commbus.rs
@@ -110,11 +110,7 @@ impl<'a> CommBusEvent<'a> {
                 this.callback.as_ref() as *const _ as *mut _,
             )
         };
-        if res {
-            Some(this)
-        } else {
-            None
-        }
+        if res { Some(this) } else { None }
     }
 
     extern "C" fn c_callback(args: *const ffi::c_char, size: ffi::c_uint, ctx: *mut ffi::c_void) {

--- a/msfs/src/executor.rs
+++ b/msfs/src/executor.rs
@@ -1,4 +1,4 @@
-use futures::{channel::mpsc, Future};
+use futures::{Future, channel::mpsc};
 use std::pin::Pin;
 use std::task::Poll;
 

--- a/msfs/src/legacy.rs
+++ b/msfs/src/legacy.rs
@@ -20,11 +20,7 @@ impl SimVarF64 for f64 {
 
 impl SimVarF64 for bool {
     fn to(self) -> f64 {
-        if self {
-            1.0
-        } else {
-            0.0
-        }
+        if self { 1.0 } else { 0.0 }
     }
 
     fn from(v: f64) -> Self {

--- a/msfs/src/msfs.rs
+++ b/msfs/src/msfs.rs
@@ -40,7 +40,7 @@ pub enum MSFSEvent<'a> {
 /// Only call this function if you know what you're doing! This function is only safe
 /// to be used if one is **absolutely sure** that there is only 1 reference to it at all times!
 pub unsafe fn wrap_executor<E, T>(executor: *mut E, handle: impl FnOnce(&mut E) -> T) -> T {
-    handle(&mut *executor)
+    unsafe { handle(&mut *executor) }
 }
 
 /// Gauge

--- a/msfs/src/sys.rs
+++ b/msfs/src/sys.rs
@@ -4,10 +4,11 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 #![allow(deref_nullptr)]
+#![allow(unsafe_op_in_unsafe_fn)]
 include!(concat!(env!("OUT_DIR"), "/msfs-sys.rs"));
 
 // https://github.com/rustwasm/team/issues/291
-extern "C" {
+unsafe extern "C" {
     pub fn nvgStrokeColor(ctx: *mut NVGcontext, color: *const NVGcolor);
     pub fn nvgStrokePaint(ctx: *mut NVGcontext, paint: *const NVGpaint);
     pub fn nvgFillColor(ctx: *mut NVGcontext, color: *const NVGcolor);

--- a/msfs_derive/Cargo.toml
+++ b/msfs_derive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "msfs_derive"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["snek"]
-edition = "2018"
+edition = "2024"
 description = "This crate provides macros for MSFS"
 license = "MIT"
 

--- a/msfs_derive/src/lib.rs
+++ b/msfs_derive/src/lib.rs
@@ -3,8 +3,9 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::HashMap;
 use syn::{
+    Expr, Ident, ItemFn, ItemStruct, Lit, Meta, Token, Type,
     parse::{Parse, ParseStream, Result as SynResult},
-    parse_macro_input, Expr, Ident, ItemFn, ItemStruct, Lit, Meta, Token, Type,
+    parse_macro_input,
 };
 
 /// Declare a standalone module.
@@ -40,14 +41,14 @@ pub fn standalone_module(_args: TokenStream, item: TokenStream) -> TokenStream {
             },
         };
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn module_init() {
             unsafe {
                 ::msfs::wrap_executor(&raw mut #executor_name, |e| e.handle_init());
             }
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn module_deinit() {
             unsafe {
                 ::msfs::wrap_executor(&raw mut #executor_name, |e| e.handle_deinit());
@@ -125,7 +126,7 @@ pub fn gauge(args: TokenStream, item: TokenStream) -> TokenStream {
         };
 
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn #extern_gauge_name(
             ctx: ::msfs::sys::FsContext,
             service_id: std::os::raw::c_int,
@@ -137,14 +138,14 @@ pub fn gauge(args: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[doc(hidden)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn #extern_mouse_name(
             fx: std::os::raw::c_float,
             fy: std::os::raw::c_float,
             i_flags: std::os::raw::c_uint,
         ) {
             unsafe {
-                ::msfs::wrap_executor(&raw mut #executor_name, |e| e.handle_mouse(fx, fy, i_flags));
+               ::msfs::wrap_executor(&raw mut #executor_name, |e| e.handle_mouse(fx, fy, i_flags));
             }
          }
     };

--- a/msfs_sdk/Cargo.toml
+++ b/msfs_sdk/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "msfs_sdk"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["snek"]
-edition = "2018"
+edition = "2024"
 description = "Crate to find MSFS SDK"
 license = "MIT"
 

--- a/msfs_sdk/src/lib.rs
+++ b/msfs_sdk/src/lib.rs
@@ -7,5 +7,7 @@ pub fn calculate_msfs_sdk_path() -> Result<String, &'static str> {
             return Ok(p.to_string());
         }
     }
-    Err("Could not locate MSFS SDK. Make sure you have it installed or try setting the MSFS_SDK env var.")
+    Err(
+        "Could not locate MSFS SDK. Make sure you have it installed or try setting the MSFS_SDK env var.",
+    )
 }


### PR DESCRIPTION
This change updates the crate to be compatible with the latest edition of rust (2024 as of creating this). without introducing any breaking API changes.

I have squashed some of the existing compiler errors but the vast majority seem to be stemming from a bindgen rust file that's generated at compile time. 

Edit: I managed to get rid of the build errors by updating bindgen to the latest version


